### PR TITLE
Update node-pty for windows compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "telnet": "git+https://github.com/TooTallNate/node-telnet.git#780340617e1f223de384cdfcb7cecf0a1a6f1159"
       },
       "peerDependencies": {
-        "node-pty": "^0.10.1"
+        "node-pty": "^1.0.0"
       }
     },
     "node_modules/debug": {
@@ -44,13 +44,13 @@
       "peer": true
     },
     "node_modules/node-pty": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.10.1.tgz",
-      "integrity": "sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
-        "nan": "^2.14.0"
+        "nan": "^2.17.0"
       }
     },
     "node_modules/telnet": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "telnet": "git+https://github.com/TooTallNate/node-telnet.git#780340617e1f223de384cdfcb7cecf0a1a6f1159"
   },
   "peerDependencies": {
-    "node-pty": "^0.10.1"
+    "node-pty": "^1.0.0"
   }
 }


### PR DESCRIPTION
Node security update https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high changed child_process.spawn to not allow .bat or .cmd files to be passed. `install` script for pty in version 0.10.1 was trying to do so, causing npm install to fail. Updating to 1.0.0 resolves this